### PR TITLE
Fix your Gitter badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Intecture [![Build Status](https://travis-ci.org/intecture/api.svg?branch=master)](https://travis-ci.org/intecture/api) [![Coverage Status](https://coveralls.io/repos/github/Intecture/api/badge.svg?branch=master)](https://coveralls.io/github/Intecture/api?branch=master) [![Gitter](https://badges.gitter.im/Join\ Chat.svg)](https://gitter.im/intecture/Lobby)
+# Intecture [![Build Status](https://travis-ci.org/intecture/api.svg?branch=master)](https://travis-ci.org/intecture/api) [![Coverage Status](https://coveralls.io/repos/github/Intecture/api/badge.svg?branch=master)](https://coveralls.io/github/Intecture/api?branch=master) [![Gitter](https://badges.gitter.im/Join/%20Chat.svg)](https://gitter.im/intecture/Lobby)
 
 Intecture is a developer friendly, language agnostic configuration management tool for server systems.
 


### PR DESCRIPTION
The url to the SVG image needed to be URL encoded as the slash was escaping it in Markdown originally.